### PR TITLE
Bugfix: latentIV tests fail on m1mac

### DIFF
--- a/tests/testthat/test-correctness_latentIV.R
+++ b/tests/testthat/test-correctness_latentIV.R
@@ -5,25 +5,28 @@ data("dataLatentIV")
 context("Correctness - latentIV - Formula transformations")
 
 test_that("Transformations are correct", {
-  expect_silent(correct.res <- latentIV(formula = y ~ P, data = dataLatentIV, verbose = FALSE))
-  # Can handle transformations in LHS
-  data.altered   <- dataLatentIV
-  data.altered$y <- exp(data.altered$y)
-  expect_silent(res.trans.lhs <- latentIV(formula = log(y) ~ P, data = data.altered, verbose = FALSE))
-  expect_equal(coef(res.trans.lhs), coef(correct.res))
-  expect_equal(coef(summary(res.trans.lhs)), coef(summary(correct.res)))
+  # Same result when transformation applied to LHS or RHS as if directly to data
+  #   testing log(exp()) gives same as no transformations yields numerical differences on M1 architectures
 
-  # Can handle transformations in RHS1
-  data.altered    <- dataLatentIV
-  data.altered$P <- exp(data.altered$P)
-  expect_silent(res.trans.rhs1  <- latentIV(formula = y ~ log(P), data = data.altered, verbose = FALSE))
-  expect_equal(coef(res.trans.rhs1), coef(correct.res), check.attributes=FALSE)
-  expect_equal(coef(summary(res.trans.rhs1)), coef(summary(correct.res)), check.attributes=FALSE)
+  data.altered.y   <- dataLatentIV
+  data.altered.y$y <- data.altered.y$y/2 + 1.23
 
+  expect_silent(res.trans.lhs <- latentIV(formula = I(y/2 + 1.23) ~ P, data = dataLatentIV, verbose = FALSE))
+  expect_silent(res.data.trans.lhs <- latentIV(formula = y ~ P, data = data.altered.y, verbose = FALSE))
+  expect_equal(coef(res.trans.lhs), coef(res.data.trans.lhs), check.attributes=FALSE)
+  expect_equal(coef(summary(res.trans.lhs)), coef(summary(res.data.trans.lhs)), check.attributes=FALSE)
+
+
+  data.altered.P   <- dataLatentIV
+  data.altered.P$P <- data.altered.P$P/2 + 1.23
+  expect_silent(res.trans.rhs <- latentIV(formula = y ~ I(P/2 + 1.23), data = dataLatentIV, verbose = FALSE))
+  expect_silent(res.data.trans.rhs <- latentIV(formula = y ~ P, data = data.altered.P, verbose = FALSE))
+  expect_equal(coef(res.trans.rhs), coef(res.data.trans.rhs), check.attributes=FALSE)
+  expect_equal(coef(summary(res.trans.rhs)), coef(summary(res.data.trans.rhs)), check.attributes=FALSE)
 
   # ensure that theta5 (group membership probability) is in [0,1]
-  expect_true(coef(res.trans.rhs1, complete = TRUE)["theta5"] >= 0 &&
-              coef(res.trans.rhs1, complete = TRUE)["theta5"] <= 1)
+  expect_true(coef(res.trans.rhs, complete = TRUE)["theta5"] >= 0 &&
+              coef(res.trans.rhs, complete = TRUE)["theta5"] <= 1)
 })
 
 # Data sorting ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
May have gotten removed from CRAN because M1mac tests were failing.
See https://cran-archive.r-project.org/web/checks/2022/2022-05-05_check_results_REndo.html