### PR TITLE
Fix HTML tidy CRAN notes 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,5 +41,5 @@ Suggests:
     R.rsp
 LinkingTo: Rcpp, RcppEigen
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 VignetteBuilder: R.rsp

--- a/NEWS.md
+++ b/NEWS.md
@@ -137,5 +137,5 @@
 ### BUG FIXES
 * Many
 
-# DEPRECATED AND DEFUNCT
+### DEPRECATED AND DEFUNCT
 * The multilevel function is temporarily removed from the package due to ongoing work on it

--- a/R/f_copulacorrection_interface.R
+++ b/R/f_copulacorrection_interface.R
@@ -26,6 +26,7 @@
 #'
 #'
 #' Consider the model:
+#'
 #' \ifelse{html}{\out{<br><div style="text-align:center">Y<sub>t</sub>=&beta;<sub>0</sub>+&beta;<sub>1</sub>P<sub>t</sub>+&beta;<sub>2</sub>X<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{\deqn{Y_{t}=\beta_{0}+ \beta_{1} P_{t} + \beta_{2} X_{t} + \epsilon_{t}}}
 #'
 #' where \eqn{t=1,..,T} indexes either time or cross-sectional units, \ifelse{html}{\out{Y<sub>t</sub>}}{\eqn{Y_{t}}} is a \eqn{1x1} response variable,
@@ -37,6 +38,7 @@
 #'
 #' The marginal distribution of the endogenous regressor \ifelse{html}{\out{P<sub>t</sub>}}{\eqn{P_{t}}} is obtained using the Epanechnikov
 #' kernel density estimator (Epanechnikov, 1969), as below:
+#'
 #' \ifelse{html}{\out{<br><div style="text-align:center">h&#770;(p)=1/(T&#183;b) &sum;(K&#183;((p-P<sub>t</sub>)/b))</div>}}{\deqn{\hat{h}(p)=\frac{1}{T\cdot b}\sum_{t=1}^{T}K\left(\frac{p-P_{t}}{b}\right)}}
 #'
 #' where \ifelse{html}{\out{P<sub>t</sub>}}{\eqn{P_{t}}} is the endogenous regressor,

--- a/R/f_heterrorsIV.R
+++ b/R/f_heterrorsIV.R
@@ -13,6 +13,7 @@
 #' no external instruments are available or to supplement external instruments to improve the efficiency of the
 #' IV estimator.
 #' Consider the model in the equation:
+#'
 #' \ifelse{html}{\out{<br><div style="text-align:center">y<sub>t</sub>=&beta;<sub>0</sub>+&beta;<sub>1</sub>P<sub>t</sub>+&beta;<sub>2</sub>X<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{\deqn{ y_{t}=\beta_{0}+ \beta_{1} P_{t} + \beta_{2} X_{t} + \epsilon_{t}}}
 #'
 #' where \eqn{t=1,..,T} indexes either time or cross-sectional units.The endogeneity problem arises from the correlation of

--- a/R/f_highermomentsIV.R
+++ b/R/f_highermomentsIV.R
@@ -13,6 +13,7 @@
 #' \subsection{Method}{
 #'
 #' Consider the model:
+#'
 #' \ifelse{html}{\out{<br><div style="text-align:center">Y<sub>t</sub>=&beta;<sub>0</sub> + &beta;<sub>1</sub>X<sub>t</sub>+&alpha;P<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{\deqn{ Y_{t} = \beta_{0}+ \beta_{1}X_{t} + \alpha P_{t}+\epsilon_{t} \hspace{0.3cm} (1) }}
 #'
 #' \ifelse{html}{\out{<div style="text-align:center">P<sub>t</sub>=Z<sub>t</sub>+&nu;<sub>t</sub></div>}}{\deqn{ P_{t} = \gamma Z_{t}+\nu_{t} \hspace{2.5 cm} (2)}}

--- a/R/f_latentIV.R
+++ b/R/f_latentIV.R
@@ -16,6 +16,7 @@
 #' @details
 #'
 #' Let's consider the model:
+#'
 #' \ifelse{html}{\out{<br><div style="text-align:center">Y<sub>t</sub>=&beta;<sub>0</sub>+&alpha;P<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{ \deqn{Y_{t} = \beta_{0} + \alpha P_{t} + \epsilon_{t}}}
 #' \ifelse{html}{\out{<div style="text-align:center">P<sub>t</sub>=&pi;'Z<sub>t</sub>+&nu;<sub>t</sub></div>}}{ \deqn{P_{t}=\pi^{'}Z_{t} + \nu_{t}}}
 #'
@@ -33,6 +34,7 @@
 #' \code{latentIV} considers \ifelse{html}{\out{Z<sub>t</sub>'}}{\eqn{Z_{t}^{'}}} to be a latent, discrete, exogenous variable with an unknown number of groups \eqn{m} and \eqn{\pi} is a vector of group means.
 #' It is assumed that \eqn{Z} is independent of the error terms \eqn{\epsilon} and \eqn{\nu} and that it has at least two groups with different means.
 #' The structural and random errors are considered normally distributed with mean zero and variance-covariance matrix \eqn{\Sigma}:
+#'
 #' \ifelse{html}{\out{<div style="text-align:center">&Sigma;=(&sigma;<sub>&epsilon;</sub><sup>2</sup>, &sigma;<sub>0</sub><sup>2</sup>,
 #' <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&sigma;<sub>0</sub><sup>2</sup>, &sigma;<sub>&nu;</sub><sup>2</sup>)</div>}}{
 #' \deqn{\Sigma = \left(

--- a/man/copulaCorrection.Rd
+++ b/man/copulaCorrection.Rd
@@ -65,6 +65,7 @@ of correlations between the two marginals.
 
 
 Consider the model:
+
 \ifelse{html}{\out{<br><div style="text-align:center">Y<sub>t</sub>=&beta;<sub>0</sub>+&beta;<sub>1</sub>P<sub>t</sub>+&beta;<sub>2</sub>X<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{\deqn{Y_{t}=\beta_{0}+ \beta_{1} P_{t} + \beta_{2} X_{t} + \epsilon_{t}}}
 
 where \eqn{t=1,..,T} indexes either time or cross-sectional units, \ifelse{html}{\out{Y<sub>t</sub>}}{\eqn{Y_{t}}} is a \eqn{1x1} response variable,
@@ -76,6 +77,7 @@ where \eqn{t=1,..,T} indexes either time or cross-sectional units, \ifelse{html}
 
 The marginal distribution of the endogenous regressor \ifelse{html}{\out{P<sub>t</sub>}}{\eqn{P_{t}}} is obtained using the Epanechnikov
 kernel density estimator (Epanechnikov, 1969), as below:
+
 \ifelse{html}{\out{<br><div style="text-align:center">h&#770;(p)=1/(T&#183;b) &sum;(K&#183;((p-P<sub>t</sub>)/b))</div>}}{\deqn{\hat{h}(p)=\frac{1}{T\cdot b}\sum_{t=1}^{T}K\left(\frac{p-P_{t}}{b}\right)}}
 
 where \ifelse{html}{\out{P<sub>t</sub>}}{\eqn{P_{t}}} is the endogenous regressor,

--- a/man/hetErrorsIV.Rd
+++ b/man/hetErrorsIV.Rd
@@ -34,6 +34,7 @@ The instruments are constructed as simple functions of the model's data. The met
 no external instruments are available or to supplement external instruments to improve the efficiency of the
 IV estimator.
 Consider the model in the equation:
+
 \ifelse{html}{\out{<br><div style="text-align:center">y<sub>t</sub>=&beta;<sub>0</sub>+&beta;<sub>1</sub>P<sub>t</sub>+&beta;<sub>2</sub>X<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{\deqn{ y_{t}=\beta_{0}+ \beta_{1} P_{t} + \beta_{2} X_{t} + \epsilon_{t}}}
 
 where \eqn{t=1,..,T} indexes either time or cross-sectional units.The endogeneity problem arises from the correlation of

--- a/man/higherMomentsIV.Rd
+++ b/man/higherMomentsIV.Rd
@@ -31,6 +31,7 @@ An important assumption for identification is that the endogenous variable has a
 \subsection{Method}{
 
 Consider the model:
+
 \ifelse{html}{\out{<br><div style="text-align:center">Y<sub>t</sub>=&beta;<sub>0</sub> + &beta;<sub>1</sub>X<sub>t</sub>+&alpha;P<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{\deqn{ Y_{t} = \beta_{0}+ \beta_{1}X_{t} + \alpha P_{t}+\epsilon_{t} \hspace{0.3cm} (1) }}
 
 \ifelse{html}{\out{<div style="text-align:center">P<sub>t</sub>=Z<sub>t</sub>+&nu;<sub>t</sub></div>}}{\deqn{ P_{t} = \gamma Z_{t}+\nu_{t} \hspace{2.5 cm} (2)}}

--- a/man/latentIV.Rd
+++ b/man/latentIV.Rd
@@ -50,6 +50,7 @@ the structural error is normally distributed.
 }
 \details{
 Let's consider the model:
+
 \ifelse{html}{\out{<br><div style="text-align:center">Y<sub>t</sub>=&beta;<sub>0</sub>+&alpha;P<sub>t</sub>+&epsilon;<sub>t</sub></div>}}{ \deqn{Y_{t} = \beta_{0} + \alpha P_{t} + \epsilon_{t}}}
 \ifelse{html}{\out{<div style="text-align:center">P<sub>t</sub>=&pi;'Z<sub>t</sub>+&nu;<sub>t</sub></div>}}{ \deqn{P_{t}=\pi^{'}Z_{t} + \nu_{t}}}
 
@@ -67,6 +68,7 @@ through \ifelse{html}{\out{E(&epsilon;&nu;)=&sigma;<sub>&epsilon;&nu;</sub>}}{\e
 \code{latentIV} considers \ifelse{html}{\out{Z<sub>t</sub>'}}{\eqn{Z_{t}^{'}}} to be a latent, discrete, exogenous variable with an unknown number of groups \eqn{m} and \eqn{\pi} is a vector of group means.
 It is assumed that \eqn{Z} is independent of the error terms \eqn{\epsilon} and \eqn{\nu} and that it has at least two groups with different means.
 The structural and random errors are considered normally distributed with mean zero and variance-covariance matrix \eqn{\Sigma}:
+
 \ifelse{html}{\out{<div style="text-align:center">&Sigma;=(&sigma;<sub>&epsilon;</sub><sup>2</sup>, &sigma;<sub>0</sub><sup>2</sup>,
 <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&sigma;<sub>0</sub><sup>2</sup>, &sigma;<sub>&nu;</sub><sup>2</sup>)</div>}}{
 \deqn{\Sigma = \left(


### PR DESCRIPTION
"Warning: inserting implicit < p >"  and parsing of NEWS.md

```
Result: NOTE
    Problems with news in 'NEWS.md':
     Cannot extract version info from the following section titles:
     DEPRECATED AND DEFUNCT

Version: 2.4.5
Check: HTML version of manual
Result: NOTE
    Found the following HTML validation problems:
    copulaCorrection.html:85:1: Warning: inserting implicit <p>
    copulaCorrection.html:96:1: Warning: inserting implicit <p>
    hetErrorsIV.html:66:1: Warning: inserting implicit <p>
    higherMomentsIV.html:62:1: Warning: inserting implicit <p>
    latentIV.html:75:1: Warning: inserting implicit <p>
    latentIV.html:92:1: Warning: inserting implicit <p>
```