### PR TITLE
Bugfix: Latest Matrix package update breaks some multilevelIV input checks

### DIFF
--- a/R/f_multilevelIV.R
+++ b/R/f_multilevelIV.R
@@ -289,14 +289,12 @@ multilevelIV <- function(formula, data, lmer.control=lmerControl(optimizer = "Ne
                                   control = lmer.control),
                        error = function(e)return(e))
   if(is(res.lmer, "error"))
-    stop("lme4::lmer() could not be fitted with error: ",
-        sQuote(res.lmer$message), "\nPlease revise your data and formula.", call. = FALSE)
+    check_err_msg(paste0("lme4::lmer() could not be fitted with error: ",sQuote(res.lmer$message), "\nPlease revise your data and formula."))
 
   res.VC <- tryCatch(lme4::VarCorr(res.lmer),
                      error = function(e)return(e))
   if(is(res.VC, "error"))
-    stop("lme4::VarCorr() could not be fitted with error: ",
-         sQuote(res.VC$message), "\nPlease revise your data and formula.", call. = FALSE)
+    check_err_msg(paste0("lme4::VarCorr() could not be fitted with error: ", sQuote(res.VC$message), "\nPlease revise your data and formula."))
 
 
   # Fit multilevel model -----------------------------------------------------------------------

--- a/tests/testthat/test-inputchecks_multilevel.R
+++ b/tests/testthat/test-inputchecks_multilevel.R
@@ -109,8 +109,8 @@ test_that("Fail if level grouping id in model", {
 
 test_that("Fail if no slope provided",{
   expect_error(multilevelIV(formula = y ~ X11 + X12  + X15+ (0|CID) | endo(X11), data = dataMultilevelIV), regexp = "The above errors were encountered!")
-  expect_error(multilevelIV(formula = y ~ X11 + X12  + X15+ (0|CID)+(1|SID) | endo(X11), data = dataMultilevelIV), regexp = "Please revise your data and formula.")
-  expect_error(multilevelIV(formula = y ~ X11 + X12  + X15+ (1|CID)+(0|SID) | endo(X11), data = dataMultilevelIV), regexp = "Please revise your data and formula.")
+  expect_error(multilevelIV(formula = y ~ X11 + X12  + X15+ (0|CID)+(1|SID) | endo(X11), data = dataMultilevelIV), regexp = "The above errors were encountered!")
+  expect_error(multilevelIV(formula = y ~ X11 + X12  + X15+ (1|CID)+(0|SID) | endo(X11), data = dataMultilevelIV), regexp = "The above errors were encountered!")
 })
 
 test_that("Fail if slopes are not in model",{


### PR DESCRIPTION
`lme4::lFormula()` does no longer fail during input checks for inputs it did before. The input is still illegal but the error only appears when actually fitting `lme4::lmer()`. It is caught there but the error is not reported with the standard method `check_err_msg()` but simply with `stop()`. Replace `stop()` with `check_err_msg()` and adapt tests which still checked for the old message.